### PR TITLE
feat: add option to auto focus the first input

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -64,6 +64,19 @@ const handleComplete = (value) => {
 <MuiOtpInput length={4} onComplete={handleComplete} />
 ```
 
+
+## `autoFocus`
+
+- Type: `boolean`
+- Default: `false`
+
+Choose to auto focus the first input.
+
+```tsx
+<MuiOtpInput autoFocus />
+```
+
+
 ## `validateChar`
 
 - Type: `(value: string, index: number) => boolean`

--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -29,6 +29,7 @@ const MyComponent = () => {
       onChange={handleChange}
       onComplete={handleComplete}
       length={8}
+      autoFocus
       validateChar={(character: string, index: number) => true}
     />
   )

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -22,6 +22,7 @@ export const Primary: ComponentStory<typeof MuiOtpInput> = () => {
     <ThemeProvider theme={theme}>
       <MuiOtpInput
         length={5}
+        autoFocus
         sx={{ width: 300 }}
         gap={1}
         TextFieldsProps={{ type: 'text', size: 'medium', placeholder: '-' }}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -36,4 +36,14 @@ describe('components/MuiOtpInput', () => {
     expect(testUtils.getInputElementByIndex(2).value).toBe('')
     expect(testUtils.getInputElementByIndex(3).value).toBe('')
   })
+
+  test('should not focus first input by default', () => {
+    render(<MuiOtpInput value="abcd" />)
+    expect(testUtils.getInputElementByIndex(0)).not.toHaveFocus()
+  })
+
+  test('should focus first input according to the autoFocus prop', () => {
+    render(<MuiOtpInput value="abcd" autoFocus />)
+    expect(testUtils.getInputElementByIndex(0)).toHaveFocus()
+  })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ const MuiOtpInput = React.forwardRef(
     const {
       value,
       length,
+      autoFocus,
       onChange,
       TextFieldsProps,
       onComplete,
@@ -200,6 +201,7 @@ const MuiOtpInput = React.forwardRef(
         {valueSplitted.map(({ character, inputRef }, index) => {
           return (
             <TextFieldBox
+              autoFocus={autoFocus ? index === 0 : false}
               autoComplete="one-time-code"
               value={character}
               inputRef={inputRef}
@@ -226,6 +228,7 @@ const MuiOtpInput = React.forwardRef(
 MuiOtpInput.defaultProps = {
   value: '',
   length: 4,
+  autoFocus: false,
   validateChar: () => {
     return true
   },

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -3,7 +3,7 @@ import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextFiel
 
 type TextFieldProps = Omit<
   MuiTextFieldProps,
-  'onChange' | 'select' | 'multiline' | 'defaultValue' | 'value'
+  'onChange' | 'select' | 'multiline' | 'defaultValue' | 'value' | 'autoFocus'
 >
 
 type BoxProps = Omit<MuiBoxProps, 'onChange'>
@@ -11,6 +11,7 @@ type BoxProps = Omit<MuiBoxProps, 'onChange'>
 export interface BaseMuiOtpInputProps {
   value?: string
   length?: number
+  autoFocus?: boolean
   TextFieldsProps?: TextFieldProps
   onComplete?: (value: string) => void
   validateChar?: (character: string, index: number) => boolean


### PR DESCRIPTION
Implements #6 

This PR allows the component to auto focus the first input as a usability improvement. Some assumptions I took:

- There's no need to choose which input to focus. Maybe someone wants to focus the nth input for some reason, but it can be extended later.
- By default it won't focus anything to prevent compatibility issues, the field could be used in a form with other fields and changing the behavior could break the usage pattern.

Hope I marked all the checks for opening a PR, there's no contributing.md 😅