### PR TITLE
fix: export types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/mui-one-time-password-input.es.js",
-      "require": "./dist/mui-one-time-password-input.umd.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/mui-one-time-password-input.es.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/mui-one-time-password-input.umd.js"
+      }
     }
   },
   "repository": {


### PR DESCRIPTION
Fix issue #12
This PR to fix the package entry point on the typescript project, it will import types from `dist/index.d.ts`