### PR TITLE
feat: add placeholder display control

### DIFF
--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
 const theme = createTheme()
 
 export const Primary: StoryFn<typeof MuiOtpInput> = () => {
-  const [value, setValue] = React.useState<string>('123456')
+  const [value, setValue] = React.useState<string>('12345')
 
   const handleChange = (newValue: string) => {
     setValue(newValue)
@@ -24,7 +24,12 @@ export const Primary: StoryFn<typeof MuiOtpInput> = () => {
         autoFocus
         sx={{ width: 300 }}
         gap={1}
-        TextFieldsProps={{ type: 'text', size: 'medium', placeholder: '-' }}
+        TextFieldsProps={{
+          type: 'text',
+          size: 'medium',
+          placeholder: '12345',
+          hidePlaceholderOnInput: false
+        }}
         value={value}
         onChange={handleChange}
       />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,8 @@ const MuiOtpInput = React.forwardRef(
       onPaste,
       onFocus,
       onKeyDown,
+      placeholder,
+      hidePlaceholderOnInput,
       className: TextFieldClassName,
       ...restTextFieldsProps
     } = TextFieldsProps || {}
@@ -208,6 +210,21 @@ const MuiOtpInput = React.forwardRef(
         {...restBoxProps}
       >
         {valueSplitted.map(({ character, inputRef }, index) => {
+          let placeholderDisplayValue
+          if (!value && placeholder) {
+            placeholderDisplayValue = placeholder
+          } else {
+            placeholderDisplayValue = hidePlaceholderOnInput ? '' : placeholder
+          }
+          if (placeholder && placeholder.length === length) {
+            if (!value && placeholder) {
+              placeholderDisplayValue = placeholder[index]
+            } else {
+              placeholderDisplayValue = hidePlaceholderOnInput
+                ? ''
+                : placeholder[index]
+            }
+          }
           return (
             <TextFieldBox
               autoFocus={autoFocus ? index === 0 : false}
@@ -221,6 +238,7 @@ const MuiOtpInput = React.forwardRef(
               onFocus={handleOneInputFocus}
               onChange={handleOneInputChange}
               onKeyDown={handleOneInputKeyDown}
+              placeholder={placeholderDisplayValue}
               // We use index as the order can't be moved
               // We can't use the value as it can be duplicated
               // eslint-disable-next-line react/no-array-index-key

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -4,7 +4,7 @@ import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextFiel
 type TextFieldProps = Omit<
   MuiTextFieldProps,
   'onChange' | 'select' | 'multiline' | 'defaultValue' | 'value' | 'autoFocus'
->
+> & { hidePlaceholderOnInput?: boolean }
 
 type BoxProps = Omit<MuiBoxProps, 'onChange'>
 


### PR DESCRIPTION
## Fix for #23 
Added `hidePlaceholderOnInput?: boolean` to `TextFieldsProps` , this allows the toggle of display of placeholder as seen below when set to true and false, also added evenly distribution of `placeholder` if the length of the placeholder value is equivalent to the length of the otp input like such
```js
<MuiOtpInput
  length={5}
  // ...
  TextFieldsProps={{
    // ...
    placeholder: "12345",
  }}
/>
```

#### Distributed hidden placeholder on input
<img width="1001" alt="Screenshot 2023-07-31 at 09 42 56" src="https://github.com/viclafouch/mui-otp-input/assets/51055890/887d0542-9a31-4266-96a5-666bec19565c">

#### Distributed visible placeholder on input
<img width="1001" alt="Screenshot 2023-07-31 at 09 43 24" src="https://github.com/viclafouch/mui-otp-input/assets/51055890/5245c6c1-64a3-43a5-bc9b-001d20579a65">

#### Non-distributed visible placeholder on input
<img width="1003" alt="Screenshot 2023-07-31 at 09 44 08" src="https://github.com/viclafouch/mui-otp-input/assets/51055890/aaa64d6a-5964-427e-bbe4-4e9716da5d77">


