### PR TITLE
feat: add paste preprocessing and character transformation

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -111,6 +111,57 @@ const validateChar = (value, index) => {
 <MuiOtpInput length={4} validateChar={validateChar} />
 ```
 
+## `pastePreprocess`
+
+- Type: `'none' | 'trim' | 'digits-only' | ((value: string) => string)`
+- Default: `'none'`
+
+Pre-process pasted value before it is applied to the input.
+
+- `'none'`: No preprocessing (default for backward compatibility)
+- `'trim'`: Trim whitespace from start and end
+- `'digits-only'`: Remove all non-digit characters
+- Function: Custom preprocessing function
+
+```tsx
+// Remove spaces from pasted OTP codes
+<MuiOtpInput pastePreprocess="trim" />
+
+// Keep only digits for numeric OTP
+<MuiOtpInput pastePreprocess="digits-only" />
+
+// Custom preprocessing
+<MuiOtpInput 
+  pastePreprocess={(value) => value.replace('Code: ', '')} 
+/>
+```
+
+## `transformChar`
+
+- Type: `(character: string, index: number) => string`
+- Default: `undefined`
+
+Transform characters during input. Applied before validation.
+
+```tsx
+// Convert to uppercase
+<MuiOtpInput 
+  transformChar={(char) => char.toUpperCase()}
+  validateChar={(char) => /[A-Z0-9]/.test(char)}
+/>
+
+// Advanced example: replace visually similar characters (use with caution)
+<MuiOtpInput
+  transformChar={(char) => {
+    // Only use if you're certain users might confuse these characters
+    if (char === 'O' || char === 'o') return '0'
+    if (char === 'l' || char === 'I') return '1'
+    return char
+  }}
+  validateChar={(char) => /\d/.test(char)}
+/>
+```
+
 ## `TextFieldsProps`
 
 While not explicitly documented, the props of the MUI **[TextField](https://mui.com/api/text-field)** component can be used for each `TextField`.

--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -31,6 +31,8 @@ const MyComponent = () => {
       length={8}
       autoFocus
       validateChar={(character: string, index: number) => true}
+      transformChar={(character: string, index: number) => character.toUpperCase()}
+      pastePreprocess="trim"
     />
   )
 }

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -11,36 +11,159 @@ export default {
 
 const theme = createTheme()
 
-export const Primary: StoryFn<typeof MuiOtpInput> = () => {
-  const [value, setValue] = React.useState<string>('123456')
+export const WithTransform: StoryFn<typeof MuiOtpInput> = () => {
+  const [value, setValue] = React.useState<string>('')
 
   const handleChange = (newValue: string) => {
     setValue(newValue)
+    action('onChange')(newValue)
   }
 
   const handleComplete = (finalValue: string) => {
-    action('onCompete')(finalValue)
+    action('onComplete')(finalValue)
   }
 
   return (
     <ThemeProvider theme={theme}>
-      <MuiOtpInput
-        length={5}
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        autoFocus
-        sx={{ width: 300 }}
-        gap={1}
-        onComplete={handleComplete}
-        TextFieldsProps={(index: number) => {
-          return {
-            type: 'text',
-            size: 'medium',
-            placeholder: String(index)
-          }
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '20px',
+          padding: '20px'
         }}
-        value={value}
-        onChange={handleChange}
-      />
+      >
+        <div>
+          <h3>Character Transformation Example</h3>
+          <p style={{ fontSize: '14px', color: '#666' }}>
+            This example automatically converts lowercase letters to uppercase.
+            Try typing lowercase letters - they will be converted to uppercase
+            automatically.
+          </p>
+        </div>
+
+        <MuiOtpInput
+          length={6}
+          sx={{ width: 400 }}
+          gap={1}
+          value={value}
+          onChange={handleChange}
+          onComplete={handleComplete}
+          transformChar={(char) => {
+            return char.toUpperCase()
+          }}
+          validateChar={(char) => {
+            return /[A-Z0-9]/.test(char)
+          }}
+          TextFieldsProps={{
+            placeholder: '·',
+            helperText: 'Auto-converts to uppercase (accepts A-Z, 0-9)'
+          }}
+        />
+
+        <div style={{ fontSize: '14px' }}>
+          Current value: &quot;{value}&quot; (length: {value.length})
+        </div>
+
+        <button
+          type="button"
+          onClick={() => {
+            return setValue('')
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </ThemeProvider>
+  )
+}
+
+export const Primary: StoryFn<typeof MuiOtpInput> = () => {
+  const [value, setValue] = React.useState<string>('')
+  const [pasteMode, setPasteMode] = React.useState<
+    'none' | 'trim' | 'digits-only'
+  >('digits-only')
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue)
+    action('onChange')(newValue)
+  }
+
+  const handleComplete = (finalValue: string) => {
+    action('onComplete')(finalValue)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '20px',
+          padding: '20px'
+        }}
+      >
+        <div>
+          <h3>Test Paste Preprocessing</h3>
+          <div style={{ marginBottom: '10px' }}>
+            <label>
+              Paste Preprocess Mode:
+              <select
+                value={pasteMode}
+                onChange={(e) => {
+                  return setPasteMode(e.target.value as any)
+                }}
+                style={{ marginLeft: '10px' }}
+              >
+                <option value="none">none (original behavior)</option>
+                <option value="trim">trim (remove edge spaces)</option>
+                <option value="digits-only">
+                  digits-only (keep only digits)
+                </option>
+              </select>
+            </label>
+          </div>
+          <div
+            style={{ marginBottom: '10px', fontSize: '14px', color: '#666' }}
+          >
+            Try copying and pasting these values:
+            <ul>
+              <li>&quot; 123456 &quot; (with spaces)</li>
+              <li>&quot;12 34 56&quot; (spaces inside)</li>
+              <li>&quot;Code: 123-456&quot; (with extra characters)</li>
+            </ul>
+          </div>
+        </div>
+
+        <MuiOtpInput
+          length={6}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          sx={{ width: 400 }}
+          gap={1}
+          onComplete={handleComplete}
+          pastePreprocess={pasteMode}
+          TextFieldsProps={{
+            type: 'text',
+            size: 'medium'
+          }}
+          value={value}
+          onChange={handleChange}
+        />
+
+        <div style={{ fontSize: '14px' }}>
+          Current value: &quot;{value}&quot; (length: {value.length})
+        </div>
+
+        <button
+          type="button"
+          onClick={() => {
+            return setValue('')
+          }}
+        >
+          Clear
+        </button>
+      </div>
     </ThemeProvider>
   )
 }

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -8,6 +8,16 @@ type TextFieldProps = Omit<
 
 type BoxProps = Omit<MuiBoxProps, 'onChange' | 'onBlur'>
 
+export type PastePreprocess =
+  // No preprocessing (default for backward compatibility)
+  | 'none'
+  // Trim whitespace from start and end
+  | 'trim'
+  // Remove all non-digit characters
+  | 'digits-only'
+  // Custom preprocessing function
+  | ((value: string) => string)
+
 export interface BaseMuiOtpInputProps {
   value?: string
   length?: number
@@ -15,8 +25,18 @@ export interface BaseMuiOtpInputProps {
   TextFieldsProps?: TextFieldProps | ((index: number) => TextFieldProps)
   onComplete?: (value: string) => void
   validateChar?: (character: string, index: number) => boolean
+  transformChar?: (character: string, index: number) => string
   onChange?: (value: string) => void
   onBlur?: (value: string, isCompleted: boolean) => void
+  /**
+   * Pre-process pasted value before it is applied to the input.
+   * - 'none': No preprocessing (default for backward compatibility)
+   * - 'trim': Trim whitespace from start and end
+   * - 'digits-only': Remove all non-digit characters
+   * - Function: Custom preprocessing function
+   * @default 'none'
+   */
+  pastePreprocess?: PastePreprocess
 }
 
 export type MuiOtpInputProps = BoxProps & BaseMuiOtpInputProps


### PR DESCRIPTION
## Summary
- Added `pastePreprocess` prop to handle pasted OTP codes with extra characters
- Added `transformChar` prop for character transformation before validation
- Fixed critical bug where spaces in pasted OTP codes occupy valuable character slots

## Problem
When users copy OTP codes with extra spaces or formatting (e.g., " 123456 "), the input was truncating the text to the specified length BEFORE validation, causing spaces to occupy character positions and preventing valid codes from being entered.

## Solution
- **pastePreprocess**: New prop with three built-in modes ('none', 'trim', 'digits-only') or custom function
- **transformChar**: New prop for transforming characters before validation (e.g., uppercase conversion)
- Unified character processing pipeline across all input methods (typing, pasting, SMS autofill)

## Changes
- Added new type definitions for `PastePreprocess` and `transformChar`
- Implemented `preprocessPastedValue` function for handling paste preprocessing
- Created `processCharacter` function that applies transformation then validation
- Updated Storybook examples to demonstrate new features
- Updated documentation with API reference and TypeScript examples
- Added .claude/ to .gitignore to prevent local settings from being committed

## Breaking Changes
None - fully backward compatible with default behavior unchanged.

## Test Plan
- [x] Manual testing with Storybook examples
- [x] Tested paste with spaces: " 123456 "
- [x] Tested paste with formatting: "Code: 123-456"
- [x] Tested character transformation (uppercase)
- [x] Tested SMS autofill compatibility
- [x] Verified backward compatibility